### PR TITLE
Add separator between contact links and also section

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
         <a href="https://twitter.com/samehome" target="_blank">@samehome on X</a>
     </div>
 
+    <hr>
+
     <div class="lead text-center">
         also:
         <a href="https://www.youtube.com/watch?v=REli837WM5o&t=520s" target="_blank">java on conf</a>,


### PR DESCRIPTION
Adds an `<hr>` between the LinkedIn/X links and the "also:" section to match the intended layout.

https://claude.ai/code/session_01HqrJSoRgWRv3KT6LNiKqH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqrJSoRgWRv3KT6LNiKqH6)_