### PR TITLE
Move contact links into page-header, remove extra hr

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,15 +29,12 @@
     <div class="page-header text-right">
         <img src="img/as_20230630_circle_small.png" class="pull-left" alt="Alex Savin"/>
         <h2 class="text-muted"><a href="https://www.linkedin.com/in/alesavin/">ale(x)sav.in</a></h2>
+        <p class="lead">
+            <a href="https://www.linkedin.com/in/alesavin/" target="_blank">LinkedIn</a>
+            &nbsp;&middot;&nbsp;
+            <a href="https://twitter.com/samehome" target="_blank">@samehome on X</a>
+        </p>
     </div>
-
-    <div class="lead text-center">
-        <a href="https://www.linkedin.com/in/alesavin/" target="_blank">LinkedIn</a>
-        &nbsp;&middot;&nbsp;
-        <a href="https://twitter.com/samehome" target="_blank">@samehome on X</a>
-    </div>
-
-    <hr>
 
     <div class="lead text-center">
         also:


### PR DESCRIPTION
Moves LinkedIn/X links inside the `page-header` div so the existing Bootstrap border-bottom acts as the single separator. Removes the standalone `<hr>` that was creating a double separator.

Result:
- photo + title + LinkedIn·X all in one block above the border
- "also:" section immediately below

https://claude.ai/code/session_01HqrJSoRgWRv3KT6LNiKqH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqrJSoRgWRv3KT6LNiKqH6)_