### PR TITLE
Update X link to x.com and simplify also section

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,28 +39,13 @@
         <div class="text-right lead">
             <a href="https://www.linkedin.com/in/alesavin/" target="_blank">LinkedIn</a>
             &nbsp;&middot;&nbsp;
-            <a href="https://twitter.com/samehome" target="_blank">X</a>
+            <a href="https://x.com/samehome" target="_blank">x.com</a>
         </div>
     </div>
 
     <hr>
 
-    <div class="section-also">
-        also:
-        <a href="https://www.youtube.com/watch?v=REli837WM5o&t=520s" target="_blank">java on conf</a>,
-        <a href="https://hyperskill.org/learn/step/8945" target="_blank">hyperskill</a>,
-        <a href="https://jobs.ciklum.com/clients/addison-global/" target="_blank">ciklum</a>,
-        <a href="https://auto.ru/dealer/" target="_blank">auto.ru</a>,
-        <a href="https://compscicenter.ru/teachers/4194/" target="_blank">сomputer science center</a>,
-        <a href="https://realty.yandex.ru/" target="_blank">realty.yandex.ru</a>,
-        <a href="https://web.archive.org/web/20140228111730/http://auto.yandex.ru/" target="_blank">auto.yandex.ru</a>,
-        <a href="https://rabota.yandex.ru" target="_blank">rabota.yandex.ru</a>,
-        <a href="https://web.archive.org/web/20181129175431/http://cikv.ru/%D0%90%D0%BD%D0%B0%D0%BB%D0%B8%D0%B7_%D0%B2%D0%BE%D0%B4%D1%8B_%D0%9F%D0%B5%D1%82%D0%B5%D1%80%D0%B1%D1%83%D1%80%D0%B3" target="_blank">cikv.ru</a>,
-        <a href="https://art-t-shok.ru" target="_blank">art-t-shok.ru</a>,
-        <a href="https://sametime.livejournal.com" target="_blank">lj:sametime</a>,
-        <a href="https://nevadeep.blogspot.ru" target="_blank">nevadeep</a>,
-        <a href="https://web.archive.org/web/20070106100734/http://www.plastique.spb.ru/ru/main/" target="_blank">plastique</a>
-    </div>
+    <div class="section-also">also: <a href="https://www.youtube.com/watch?v=REli837WM5o&t=520s" target="_blank">java on conf</a>, <a href="https://hyperskill.org/learn/step/8945" target="_blank">hyperskill</a>, <a href="https://jobs.ciklum.com/clients/addison-global/" target="_blank">ciklum</a>, <a href="https://auto.ru/dealer/" target="_blank">auto.ru</a>, <a href="https://compscicenter.ru/teachers/4194/" target="_blank">computer science center</a>, <a href="https://realty.yandex.ru/" target="_blank">realty.yandex.ru</a>, <a href="https://web.archive.org/web/20140228111730/http://auto.yandex.ru/" target="_blank">auto.yandex.ru</a>, <a href="https://rabota.yandex.ru" target="_blank">rabota.yandex.ru</a>, <a href="https://web.archive.org/web/20181129175431/http://cikv.ru/%D0%90%D0%BD%D0%B0%D0%BB%D0%B8%D0%B7_%D0%B2%D0%BE%D0%B4%D1%8B_%D0%9F%D0%B5%D1%82%D0%B5%D1%80%D0%B1%D1%83%D1%80%D0%B3" target="_blank">cikv.ru</a>, <a href="https://art-t-shok.ru" target="_blank">art-t-shok.ru</a>, <a href="https://sametime.livejournal.com" target="_blank">lj:sametime</a>, <a href="https://nevadeep.blogspot.ru" target="_blank">nevadeep</a>, <a href="https://web.archive.org/web/20070106100734/http://www.plastique.spb.ru/ru/main/" target="_blank">plastique</a></div>
 
     <hr>
 


### PR DESCRIPTION
## Summary
- Update Twitter link from `twitter.com/samehome` to `x.com/samehome`, label changed from "X" to "x.com"
- Simplify "also" section markup — inline text with no extra whitespace, wraps naturally

https://claude.ai/code/session_01MQR5DJBa3HbFXj1E7oskn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQR5DJBa3HbFXj1E7oskn1)_