### PR TITLE
Font size increase, heading cleanup, claude certified link

### DIFF
--- a/css/alesavin.css
+++ b/css/alesavin.css
@@ -9,7 +9,7 @@ body {
   padding-bottom: 20px;
   margin: 0;
   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 13px;
+  font-size: 14.3px;
   line-height: 1.7;
   color: #222;
   background: #fff;
@@ -44,7 +44,7 @@ hr {
 }
 
 .topbar {
-  font-size: 11px;
+  font-size: 12.1px;
   letter-spacing: 0.06em;
   color: #999;
 }
@@ -72,14 +72,14 @@ hr {
 }
 
 .hero .prompt {
-  font-size: 11px;
+  font-size: 12.1px;
   color: #999;
   margin-bottom: 6px;
 }
 
 .hero h1 {
   font-family: inherit;
-  font-size: 28px;
+  font-size: 30.8px;
   font-weight: 500;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -97,7 +97,7 @@ hr {
 
 .hero .byline {
   margin-top: 8px;
-  font-size: 12.5px;
+  font-size: 13.8px;
   color: #555;
 }
 
@@ -105,7 +105,7 @@ hr {
   margin-top: 16px;
   display: flex;
   gap: 16px;
-  font-size: 13px;
+  font-size: 14.3px;
 }
 
 .hero .links a {
@@ -121,7 +121,7 @@ hr {
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 11px;
+  font-size: 12.1px;
   color: #999;
   margin: 24px 0 18px;
 }
@@ -135,7 +135,7 @@ hr {
 /* --- "also" link list ----------------------------------------- */
 
 .section-also {
-  font-size: 12.5px;
+  font-size: 13.8px;
   line-height: 1.9;
   color: #555;
 }
@@ -155,7 +155,7 @@ hr {
 /* --- Footer --------------------------------------------------- */
 
 .section-copyright {
-  font-size: 10.5px;
+  font-size: 11.6px;
   color: #999;
   text-align: center;
   padding-bottom: 20px;

--- a/css/alesavin.css
+++ b/css/alesavin.css
@@ -9,7 +9,7 @@ body {
   padding-bottom: 20px;
   margin: 0;
   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 14.3px;
+  font-size: 14px;
   line-height: 1.7;
   color: #222;
   background: #fff;
@@ -44,7 +44,7 @@ hr {
 }
 
 .topbar {
-  font-size: 12.1px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   color: #999;
 }
@@ -72,14 +72,14 @@ hr {
 }
 
 .hero .prompt {
-  font-size: 12.1px;
+  font-size: 12px;
   color: #999;
   margin-bottom: 6px;
 }
 
 .hero h1 {
   font-family: inherit;
-  font-size: 30.8px;
+  font-size: 31px;
   font-weight: 500;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -97,7 +97,7 @@ hr {
 
 .hero .byline {
   margin-top: 8px;
-  font-size: 13.8px;
+  font-size: 14px;
   color: #555;
 }
 
@@ -105,7 +105,7 @@ hr {
   margin-top: 16px;
   display: flex;
   gap: 16px;
-  font-size: 14.3px;
+  font-size: 14px;
 }
 
 .hero .links a {
@@ -121,7 +121,7 @@ hr {
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 12.1px;
+  font-size: 12px;
   color: #999;
   margin: 24px 0 18px;
 }
@@ -135,7 +135,7 @@ hr {
 /* --- "also" link list ----------------------------------------- */
 
 .section-also {
-  font-size: 13.8px;
+  font-size: 14px;
   line-height: 1.9;
   color: #555;
 }
@@ -155,7 +155,7 @@ hr {
 /* --- Footer --------------------------------------------------- */
 
 .section-copyright {
-  font-size: 11.6px;
+  font-size: 12px;
   color: #999;
   text-align: center;
   padding-bottom: 20px;

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <img src="img/as_20230630_circle_small.png" class="avatar" alt="Alexander Savin"/>
         <div class="hero-text">
             <div class="prompt"><span class="caret">$</span> whoami</div>
-            <h1><a href="https://www.linkedin.com/in/alesavin/" rel="noopener noreferrer">ale<span class="x">(x)</span>sav.in</a></h1>
+            <h1>ale<span class="x">(x)</span>sav.in</h1>
             <div class="byline">Alexander Savin · software engineer</div>
             <div class="links">
                 <a href="https://www.linkedin.com/in/alesavin/" target="_blank" rel="noopener noreferrer">&rarr; linkedin</a>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
     </div>
 
     <div class="section-also">
-        <a href="https://www.youtube.com/watch?v=REli837WM5o&t=520s" target="_blank" rel="noopener noreferrer">java on conf</a>
+        <a href="https://verify.skilljar.com/c/3amdmn58fm8o" target="_blank" rel="noopener noreferrer">claude certified</a>
+        <span class="sep"> / </span><a href="https://www.youtube.com/watch?v=REli837WM5o&t=520s" target="_blank" rel="noopener noreferrer">java on conf</a>
         <span class="sep"> / </span><a href="https://hyperskill.org/learn/step/8945" target="_blank" rel="noopener noreferrer">hyperskill</a>
         <span class="sep"> / </span><a href="https://jobs.ciklum.com/clients/addison-global/" target="_blank" rel="noopener noreferrer">ciklum</a>
         <span class="sep"> / </span><a href="https://auto.ru/dealer/" target="_blank" rel="noopener noreferrer">auto.ru</a>


### PR DESCRIPTION
## Summary

- Increase all font sizes by ~10% (rounded to whole px values)
- Remove link from `ale(x)sav.in` h1 — plain text only
- Add "claude certified" as first item in the also section

## Font size changes

| Selector | Before | After |
|---|---|---|
| `body`, `.hero .links` | 13px | 14px |
| `.topbar`, `.hero .prompt`, `.ls-divider` | 11px | 12px |
| `.hero h1` | 28px | 31px |
| `.hero .byline`, `.section-also` | 12.5px | 14px |
| `.section-copyright` | 10.5px | 12px |

https://claude.ai/code/session_019kBNCb2NMS7ct4pDHCzawG

---
_Generated by [Claude Code](https://claude.ai/code/session_019kBNCb2NMS7ct4pDHCzawG)_