### PR TITLE
Remove dead .hero h1 a CSS rule

### DIFF
--- a/css/alesavin.css
+++ b/css/alesavin.css
@@ -86,11 +86,6 @@ hr {
   margin: 0;
 }
 
-.hero h1 a {
-  color: #222;
-  text-decoration: none;
-}
-
 .hero h1 .x {
   color: #337ab7;
 }


### PR DESCRIPTION
Removes the `.hero h1 a` rule which became unreachable after the h1 link was removed in PR #11.

Depends on #11 — targeted at that branch so the diff stays minimal (5 lines).

https://claude.ai/code/session_019kBNCb2NMS7ct4pDHCzawG

---
_Generated by [Claude Code](https://claude.ai/code/session_019kBNCb2NMS7ct4pDHCzawG)_